### PR TITLE
First release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 1.0.0 (2020/08/18)
+## 1.0.0 (2020/08/24)
 
 * Initial version (docker/build-push-action#87)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 1.0.0 (2020/08/24)
+## 0.9.0 (2020/08/??)
 
 * Initial version (docker/build-push-action#87)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0 (2020/08/18)
+
+* Initial version (docker/build-push-action#87)


### PR DESCRIPTION
Ref. docker/build-push-action#87

v1 for our **setup-buildx-action** is ready.

When the repo is made public:

* [x] Uncomment [this job](https://github.com/docker/setup-buildx-action/blob/6a7c1dc2ba44f768e571cdd730d7b8306eeeaa09/.github/workflows/ci.yml#L124-L156) (need [setup-qemu-action](https://github.com/docker/setup-qemu-action) made public too)
* [ ] [Enable Codecov for the repo?](https://codecov.io/gh/docker/setup-buildx-action).
  * If so, [add the `CODECOV_TOKEN` secret](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository) on the repo to be able to push coverage reports through our [test workflow](https://github.com/docker/setup-buildx-action/blob/master/.github/workflows/test.yml#L27-L33).
  * Add Codecov badge to README: `[![Codecov](https://img.shields.io/codecov/c/github/docker/setup-buildx-action?logo=codecov&style=flat-square)](https://codecov.io/gh/docker/setup-buildx-action)`
* [ ] Publish the action on the marketplace
* [x] Remove [`setup-buildx` folder](https://github.com/docker/build-push-action/tree/v2-working-branch) from build-push action `v2-working-branch` and update workflows
* [x] @justincormack Change repo description to `GitHub Action to set up Docker Buildx` instead?

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>