### PR TITLE
Temporarly set buildkit container image to moby/buildkit:v0.8-beta

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,11 +33,21 @@ async function run(): Promise<void> {
     if (inputs.driver !== 'docker') {
       core.info('🔨 Creating a new builder instance...');
       let createArgs: Array<string> = ['buildx', 'create', '--name', builderName, '--driver', inputs.driver];
-      await context.asyncForEach(inputs.driverOpts, async driverOpt => {
-        createArgs.push('--driver-opt', driverOpt);
-      });
-      if (inputs.buildkitdFlags && semver.satisfies(buildxVersion, '>=0.3.0')) {
-        createArgs.push('--buildkitd-flags', inputs.buildkitdFlags);
+      if (semver.satisfies(buildxVersion, '>=0.3.0')) {
+        let hasImageDriverOpt: boolean = false;
+        await context.asyncForEach(inputs.driverOpts, async driverOpt => {
+          if (driverOpt.startsWith('image=')) {
+            hasImageDriverOpt = true;
+          }
+          createArgs.push('--driver-opt', driverOpt);
+        });
+        if (!hasImageDriverOpt) {
+          //FIXME: Temporary fix (docker/build-push-action#154, docker/build-push-action#162)
+          createArgs.push('--driver-opt', 'image=moby/buildkit:v0.8-beta');
+        }
+        if (inputs.buildkitdFlags) {
+          createArgs.push('--buildkitd-flags', inputs.buildkitdFlags);
+        }
       }
       if (inputs.use) {
         createArgs.push('--use');


### PR DESCRIPTION
Closes docker/build-push-action#154
Closes docker/build-push-action#162
Fix docker/build-push-action#126

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>