### PR TITLE
Tweak BuildKit step log limits 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -518,6 +518,8 @@ const buildx = __importStar(__webpack_require__(295));
 const context = __importStar(__webpack_require__(842));
 const mexec = __importStar(__webpack_require__(757));
 const stateHelper = __importStar(__webpack_require__(647));
+const buildkitStepLogMaxSize = 1024 * 8192;
+const buildkitStepLogMaxSpeed = -1;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -544,6 +546,8 @@ function run() {
                     yield context.asyncForEach(inputs.driverOpts, (driverOpt) => __awaiter(this, void 0, void 0, function* () {
                         createArgs.push('--driver-opt', driverOpt);
                     }));
+                    createArgs.push('--driver-opt', 'env.BUILDKIT_STEP_LOG_MAX_SIZE=' + buildkitStepLogMaxSize);
+                    createArgs.push('--driver-opt', 'env.BUILDKIT_STEP_LOG_MAX_SPEED=' + buildkitStepLogMaxSpeed);
                     if (inputs.buildkitdFlags) {
                         createArgs.push('--buildkitd-flags', inputs.buildkitdFlags);
                     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,9 @@ import * as context from './context';
 import * as mexec from './exec';
 import * as stateHelper from './state-helper';
 
+const buildkitStepLogMaxSize = 1024 * 8192;
+const buildkitStepLogMaxSpeed = -1;
+
 async function run(): Promise<void> {
   try {
     if (os.platform() !== 'linux') {
@@ -38,6 +41,8 @@ async function run(): Promise<void> {
         await context.asyncForEach(inputs.driverOpts, async driverOpt => {
           createArgs.push('--driver-opt', driverOpt);
         });
+        createArgs.push('--driver-opt', 'env.BUILDKIT_STEP_LOG_MAX_SIZE=' + buildkitStepLogMaxSize);
+        createArgs.push('--driver-opt', 'env.BUILDKIT_STEP_LOG_MAX_SPEED=' + buildkitStepLogMaxSpeed);
         if (inputs.buildkitdFlags) {
           createArgs.push('--buildkitd-flags', inputs.buildkitdFlags);
         }


### PR DESCRIPTION
Ref. moby/buildkit#1754 https://github.com/docker/buildx/issues/484#issuecomment-749352728

Increase max log size to 8MB based on [GitHub Runner context](https://github.com/actions/runner/blob/fc3ca9bb92cb51850d302edb07d0baa38d4e01ed/src/Runner.Common/HostContext.cs#L49) and remove log speed limit.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>