### PR TITLE
Revert BuildKit step log limits tweak

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -518,8 +518,6 @@ const buildx = __importStar(__webpack_require__(295));
 const context = __importStar(__webpack_require__(842));
 const mexec = __importStar(__webpack_require__(757));
 const stateHelper = __importStar(__webpack_require__(647));
-const buildkitStepLogMaxSize = 1024 * 8192;
-const buildkitStepLogMaxSpeed = -1;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -546,8 +544,6 @@ function run() {
                     yield context.asyncForEach(inputs.driverOpts, (driverOpt) => __awaiter(this, void 0, void 0, function* () {
                         createArgs.push('--driver-opt', driverOpt);
                     }));
-                    createArgs.push('--driver-opt', 'env.BUILDKIT_STEP_LOG_MAX_SIZE=' + buildkitStepLogMaxSize);
-                    createArgs.push('--driver-opt', 'env.BUILDKIT_STEP_LOG_MAX_SPEED=' + buildkitStepLogMaxSpeed);
                     if (inputs.buildkitdFlags) {
                         createArgs.push('--buildkitd-flags', inputs.buildkitdFlags);
                     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,9 +8,6 @@ import * as context from './context';
 import * as mexec from './exec';
 import * as stateHelper from './state-helper';
 
-const buildkitStepLogMaxSize = 1024 * 8192;
-const buildkitStepLogMaxSpeed = -1;
-
 async function run(): Promise<void> {
   try {
     if (os.platform() !== 'linux') {
@@ -41,8 +38,6 @@ async function run(): Promise<void> {
         await context.asyncForEach(inputs.driverOpts, async driverOpt => {
           createArgs.push('--driver-opt', driverOpt);
         });
-        createArgs.push('--driver-opt', 'env.BUILDKIT_STEP_LOG_MAX_SIZE=' + buildkitStepLogMaxSize);
-        createArgs.push('--driver-opt', 'env.BUILDKIT_STEP_LOG_MAX_SPEED=' + buildkitStepLogMaxSpeed);
         if (inputs.buildkitdFlags) {
           createArgs.push('--buildkitd-flags', inputs.buildkitdFlags);
         }


### PR DESCRIPTION
Looks like there is an issue with #46. Log is [always clipped](https://github.com/crazy-max/swarm-cronjob/runs/1648471670?check_suite_focus=true#step:8:121) even if the size is far from exceeding the current value (8MB):

```
#10 [linux/amd64 base 3/4] RUN wget -qO- https://github.com/goreleaser/goreleaser/releases/download/v0.149.0/goreleaser_Linux_x86_64.tar.gz | tar -zxvf - goreleaser   && mv goreleaser /usr/local/bin/goreleaser
#10 sha256:818465efb7410f63f04e4cff30dbf041fc97c0340568bc3381f0011d6be40efd
#10 0.197 
#10 0.197 [output clipped, log limit 8MiB reached]
#10 DONE 0.9s
```

Try to disable clipping but same behavior:

```
#9 [linux/amd64 base 2/4] RUN apk add --no-cache ca-certificates curl gcc file git musl-dev tar
#9 sha256:cb8a83450b2611af815f803a662bac9437cdf58fe7d6996fbcb878856c7a612c
#9 0.087 
#9 0.087 [output clipped, log limit -1B reached]
#9 DONE 9.1s
```

Revert #46 in the meantime. cc @tonistiigi 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>