### PR TITLE
Add config input

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Following inputs can be used as `step.with` keys
 | `install`          | Bool    | Sets up `docker build` command as an alias to `docker buildx` (default `false`) |
 | `use`              | Bool    | Switch to this builder instance (default `true`) |
 | `endpoint`         | String  | [Optional address for docker socket](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#description) or context from `docker context ls` |
+| `config`           | String  | [Optional config file path](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#config) |
 
 > `CSV` type must be a newline-delimited string
 > ```yaml

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   endpoint:
     description: 'Optional address for docker socket or context from `docker context ls`'
     required: false
+  config:
+    description: 'Optional config file path'
+    required: false
 
 outputs:
   name:

--- a/dist/index.js
+++ b/dist/index.js
@@ -554,6 +554,9 @@ function run() {
                 if (inputs.endpoint) {
                     createArgs.push(inputs.endpoint);
                 }
+                if (inputs.config) {
+                    createArgs.push('--config', inputs.config);
+                }
                 yield exec.exec('docker', createArgs);
                 core.endGroup();
                 core.startGroup(`Booting builder`);
@@ -8023,7 +8026,8 @@ function getInputs() {
                 '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host',
             install: /true/i.test(core.getInput('install')),
             use: /true/i.test(core.getInput('use')),
-            endpoint: core.getInput('endpoint')
+            endpoint: core.getInput('endpoint'),
+            config: core.getInput('config')
         };
     });
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,7 @@ export interface Inputs {
   install: boolean;
   use: boolean;
   endpoint: string;
+  config: string;
 }
 
 export async function getInputs(): Promise<Inputs> {
@@ -24,7 +25,8 @@ export async function getInputs(): Promise<Inputs> {
       '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host',
     install: /true/i.test(core.getInput('install')),
     use: /true/i.test(core.getInput('use')),
-    endpoint: core.getInput('endpoint')
+    endpoint: core.getInput('endpoint'),
+    config: core.getInput('config')
   };
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,9 @@ async function run(): Promise<void> {
       if (inputs.endpoint) {
         createArgs.push(inputs.endpoint);
       }
+      if (inputs.config) {
+        createArgs.push('--config', inputs.config);
+      }
       await exec.exec('docker', createArgs);
       core.endGroup();
 


### PR DESCRIPTION
Fixes #66 

Hi, as discussed on #66, this PR adds a new input named `config`. The input accepts a string that is the path for the [buildkitd daemon configuration file](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#config).

This is my first contribution on typescript but, if I understood the flow correctly, this change should be enough to make it work. @crazy-max please let me know how we can add a test to this.

Thanks!