### PR TITLE
Add test job for config input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,38 @@ jobs:
         with:
           endpoint: mycontext
 
+  config:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Create buildkitd conf
+        run: |
+          cat > /tmp/buildkitd.toml <<EOL
+          debug = true
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
+          EOL
+      -
+        name: Create Dockerfile
+        run: |
+          cat > ./Dockerfile <<EOL
+          FROM alpine
+          EOL
+      -
+        name: Set up Docker Buildx
+        uses: ./
+        with:
+          buildkitd-flags: --debug
+          config: /tmp/buildkitd.toml
+      -
+        name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+
   with-qemu:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Follow-up #67 

We can see config is [effectively used](https://github.com/docker/setup-buildx-action/runs/2423028804?check_suite_focus=true#step:11:20):

![image](https://user-images.githubusercontent.com/1951866/115926565-55acef80-a483-11eb-88af-31a80d3de564.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>