### PR TITLE
Enhance builder inspection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,13 @@ jobs:
         with:
           version: ${{ matrix.buildx-version }}
       -
-        name: Builder instance name
-        run: echo ${{ steps.buildx.outputs.name }}
-      -
-        name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       -
         name: Dump context
         uses: crazy-max/ghaction-dump-context@v1
@@ -55,15 +57,25 @@ jobs:
         id: buildx1
         uses: ./
       -
-        name: Builder 1 instance name
-        run: echo ${{ steps.buildx1.outputs.name }}
+        name: Inspect builder 1
+        run: |
+          echo "Name:      ${{ steps.buildx1.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx1.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx1.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx1.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx1.outputs.platforms }}"
       -
         name: Set up Docker Buildx 2
         id: buildx2
         uses: ./
       -
-        name: Builder 2 instance name
-        run: echo ${{ steps.buildx2.outputs.name }}
+        name: Inspect builder 2
+        run: |
+          echo "Name:      ${{ steps.buildx2.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx2.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx2.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx2.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx2.outputs.platforms }}"
 
   install:
     runs-on: ubuntu-latest
@@ -204,8 +216,10 @@ jobs:
         with:
           version: ${{ matrix.buildx-version }}
       -
-        name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
-      -
-        name: Builder instance name
-        run: echo ${{ steps.buildx.outputs.name }}
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           targets: validate
       -
+        name: Set up Docker Buildx
+        uses: ./
+      -
         name: Test
         uses: docker/bake-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Builder instance name
-        run: echo ${{ steps.buildx.outputs.name }}
-      -
-        name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
 ```
 
 ### With QEMU
@@ -129,7 +131,7 @@ Following inputs can be used as `step.with` keys
 | `install`          | Bool    | Sets up `docker build` command as an alias to `docker buildx` (default `false`) |
 | `use`              | Bool    | Switch to this builder instance (default `true`) |
 | `endpoint`         | String  | [Optional address for docker socket](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#description) or context from `docker context ls` |
-| `config`           | String  | [Optional config file path](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#config) |
+| `config`           | String  | [BuildKit config file](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#config) |
 
 > `CSV` type must be a newline-delimited string
 > ```yaml
@@ -147,8 +149,12 @@ Following outputs are available
 
 | Name          | Type    | Description                           |
 |---------------|---------|---------------------------------------|
-| `name`        | String  | Builder instance name |
-| `platforms`   | String  | Available platforms (comma separated) |
+| `name`        | String  | Builder name |
+| `driver`      | String  | Builder driver |
+| `endpoint`    | String  | Builder node endpoint |
+| `status`      | String  | Builder node status |
+| `flags`       | String  | Builder node flags (if applicable) |
+| `platforms`   | String  | Builder node platforms available (comma separated) |
 
 ### environment variables
 

--- a/__tests__/buildx.test.ts
+++ b/__tests__/buildx.test.ts
@@ -25,17 +25,19 @@ describe('parseVersion', () => {
   });
 });
 
-describe('platforms', () => {
+describe('inspect', () => {
   async function isDaemonRunning() {
     return await docker.isDaemonRunning();
   }
   (isDaemonRunning() ? it : it.skip)(
     'valid',
     async () => {
-      const platforms = buildx.platforms();
-      console.log(`platforms: ${platforms}`);
-      expect(platforms).not.toBeUndefined();
-      expect(platforms).not.toEqual('');
+      const builder = await buildx.inspect('');
+      console.log('builder', builder);
+      expect(builder).not.toBeUndefined();
+      expect(builder.name).not.toEqual('');
+      expect(builder.driver).not.toEqual('');
+      expect(builder.node_platforms).not.toEqual('');
     },
     100000
   );

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import * as context from '../src/context';
 
 describe('getInputList', () => {
@@ -78,6 +79,27 @@ describe('asyncForEach', () => {
   });
 });
 
+describe('setOutput', () => {
+  beforeEach(() => {
+    process.stdout.write = jest.fn();
+  });
+
+  it('setOutput produces the correct command', () => {
+    context.setOutput('some output', 'some value');
+    assertWriteCalls([`::set-output name=some output::some value${os.EOL}`]);
+  });
+
+  it('setOutput handles bools', () => {
+    context.setOutput('some output', false);
+    assertWriteCalls([`::set-output name=some output::false${os.EOL}`]);
+  });
+
+  it('setOutput handles numbers', () => {
+    context.setOutput('some output', 1.01);
+    assertWriteCalls([`::set-output name=some output::1.01${os.EOL}`]);
+  });
+});
+
 // See: https://github.com/actions/toolkit/blob/master/packages/core/src/core.ts#L67
 function getInputName(name: string): string {
   return `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
@@ -85,4 +107,12 @@ function getInputName(name: string): string {
 
 function setInput(name: string, value: string): void {
   process.env[getInputName(name)] = value;
+}
+
+// Assert that process.stdout.write calls called only with the given arguments.
+function assertWriteCalls(calls: string[]): void {
+  expect(process.stdout.write).toHaveBeenCalledTimes(calls.length);
+  for (let i = 0; i < calls.length; i++) {
+    expect(process.stdout.write).toHaveBeenNthCalledWith(i + 1, calls[i]);
+  }
 }

--- a/action.yml
+++ b/action.yml
@@ -33,14 +33,22 @@ inputs:
     description: 'Optional address for docker socket or context from `docker context ls`'
     required: false
   config:
-    description: 'Optional config file path'
+    description: 'BuildKit config file'
     required: false
 
 outputs:
   name:
-    description: 'Builder instance name'
+    description: 'Builder name'
+  driver:
+    description: 'Builder driver'
+  endpoint:
+    description: 'Builder node endpoint'
+  status:
+    description: 'Builder node status'
+  flags:
+    description: 'Builder node flags (if applicable)'
   platforms:
-    description: 'Available platforms (comma separated)'
+    description: 'Builder node platforms available (comma separated)'
 
 runs:
   using: 'node12'

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import * as os from 'os';
 import * as core from '@actions/core';
+import {issueCommand} from '@actions/core/lib/command';
 
 export const osPlat: string = os.platform();
 export const osArch: string = os.arch();
@@ -49,3 +50,8 @@ export const asyncForEach = async (array, callback) => {
     await callback(array[index], index, array);
   }
 };
+
+// FIXME: Temp fix https://github.com/actions/toolkit/issues/777
+export function setOutput(name: string, value: any): void {
+  issueCommand('set-output', {name}, value);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ async function run(): Promise<void> {
     core.info(`Using buildx ${buildxVersion}`);
 
     const builderName: string = inputs.driver == 'docker' ? 'default' : `builder-${require('uuid').v4()}`;
-    core.setOutput('name', builderName);
+    context.setOutput('name', builderName);
     stateHelper.setBuilderName(builderName);
 
     if (inputs.driver !== 'docker') {
@@ -69,10 +69,14 @@ async function run(): Promise<void> {
       core.endGroup();
     }
 
-    core.startGroup(`Extracting available platforms`);
-    const platforms = await buildx.platforms();
-    core.info(`${platforms}`);
-    core.setOutput('platforms', platforms);
+    core.startGroup(`Inspect builder`);
+    const builder = await buildx.inspect(builderName);
+    core.info(JSON.stringify(builder, undefined, 2));
+    context.setOutput('driver', builder.driver);
+    context.setOutput('endpoint', builder.node_endpoint);
+    context.setOutput('status', builder.node_status);
+    context.setOutput('flags', builder.node_flags);
+    context.setOutput('platforms', builder.node_platforms);
     core.endGroup();
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Refactor builder inspection and add new outputs. In a follow-up PR we will be able to display buildkitd logs (`docker logs buildx_buildkit_${builder.node_name}`) if docker-container is used to enhance debugging.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>