### PR TITLE
Allow building buildx from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,3 +313,37 @@ jobs:
           echo "Status:    ${{ steps.buildx.outputs.status }}"
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+  build-ref:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ref:
+          - master
+          - refs/tags/v0.5.1
+          - refs/pull/648/head
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: ./
+        with:
+          version: https://github.com/docker/buildx.git#${{ matrix.ref }}
+      -
+        name: Check version
+        run: |
+          docker buildx version
+      -
+        name: Create Dockerfile
+        run: |
+          cat > ./Dockerfile <<EOL
+          FROM alpine
+          EOL
+      -
+        name: Build
+        uses: docker/build-push-action@master
+        with:
+          context: .

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "printWidth": 120,
+  "printWidth": 240,
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Following inputs can be used as `step.with` keys
 
 | Name               | Type    | Description                       |
 |--------------------|---------|-----------------------------------|
-| `version`          | String  | [Buildx](https://github.com/docker/buildx) version. (eg. `v0.3.0`, `latest`) |
+| `version`          | String  | [buildx](https://github.com/docker/buildx) version. (eg. `v0.3.0`, `latest`, `https://github.com/docker/buildx.git#master`) |
 | `driver`           | String  | Sets the [builder driver](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#driver) to be used (default `docker-container`) |
 | `driver-opts`      | CSV     | List of additional [driver-specific options](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#driver-opt) (eg. `image=moby/buildkit:master`) |
 | `buildkitd-flags`  | String  | [Flags for buildkitd](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md) daemon (since [buildx v0.3.0](https://github.com/docker/buildx/releases/tag/v0.3.0)) |

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -1,5 +1,15 @@
+import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
 import * as context from '../src/context';
+
+jest.spyOn(context, 'tmpDir').mockImplementation((): string => {
+  const tmpDir = path.join('/tmp/.docker-setup-buildx-jest').split(path.sep).join(path.posix.sep);
+  if (!fs.existsSync(tmpDir)) {
+    fs.mkdirSync(tmpDir, {recursive: true});
+  }
+  return tmpDir;
+});
 
 describe('getInputList', () => {
   it('handles single line correctly', async () => {

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -1,0 +1,9 @@
+import * as git from '../src/git';
+
+describe('git', () => {
+  it('returns git remote ref', async () => {
+    const ref: string = await git.getRemoteSha('https://github.com/docker/buildx.git', 'refs/pull/648/head');
+    console.log(`ref: ${ref}`);
+    expect(ref).toEqual('f11797113e5a9b86bd976329c5dbb8a8bfdfadfa');
+  });
+});

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,0 +1,11 @@
+import * as util from '../src/util';
+
+describe('isValidUrl', () => {
+  test.each([
+    ['https://github.com/docker/buildx.git', true],
+    ['https://github.com/docker/buildx.git#refs/pull/648/head', true],
+    ['v0.4.1', false]
+  ])('given %p', async (url, expected) => {
+    expect(util.isValidUrl(url)).toEqual(expected);
+  });
+});

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+comment: false
+github_checks:
+  annotations: false

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,19 @@
+import * as exec from '@actions/exec';
+
+export async function getRemoteSha(repo: string, ref: string): Promise<string> {
+  return await exec
+    .getExecOutput(`git`, ['ls-remote', repo, ref], {
+      ignoreReturnCode: true,
+      silent: true
+    })
+    .then(res => {
+      if (res.stderr.length > 0 && res.exitCode != 0) {
+        throw new Error(res.stderr);
+      }
+      const [rsha, rref] = res.stdout.trim().split(/[\s\t]/);
+      if (rsha.length == 0) {
+        throw new Error(`Cannot find remote ref for ${repo}#${ref}`);
+      }
+      return rsha;
+    });
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,8 @@
+export function isValidUrl(url: string): boolean {
+  try {
+    new URL(url);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Closes #98 

I made some changes from what we said in #98. Now buildx will be built on-the-fly against the reference passed to `build-ref` input. Here is a workflow:

```yaml
build-ref:
    runs-on: ubuntu-latest
    strategy:
      fail-fast: false
      matrix:
        ref:
          - master
          - refs/tags/v0.5.1
          - refs/pull/648/head
    steps:
      -
        name: Checkout
        uses: actions/checkout@v2
      -
        name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v1
        with:
          build-ref: https://github.com/docker/buildx.git#${{ matrix.ref }}
      -
        name: Check version
        run: |
          docker buildx version
```

Run: https://github.com/docker/setup-buildx-action/runs/2963153312?check_suite_focus=true#step:3:94

cc @tonistiigi 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>