### PR TITLE
update GH doc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ with:
 ```
 
 If the runner is not able to access `github.com`, it will take the default one
-available on the GitHub Runner or runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server@3.2/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)"
+available on the GitHub Runner or runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)"
 for more information.
 
 ## Contributing


### PR DESCRIPTION
Super small change, but the old link hardcoding the GHE version pointed to an outdated page with a warning at the top stating such.