### PR TITLE
nit typo in README.md, csv is comma-delimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Following inputs can be used as `step.with` keys:
 >   network=host
 > ```
 
-> `CSV` type must be a newline-delimited string
+> `CSV` type must be a comma-delimited string
 > ```yaml
 > platforms: linux/amd64,linux/arm64
 > ```


### PR DESCRIPTION
First off, thank you so much for maintaining this action!

I was looking through the README and found a tiny typo. Apologies for the overhead of a full PR to fix it; feel free to dismiss and fix in the next substantive README update you have planned.