### PR TITLE
feat: bump action to use node20 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,6 @@ outputs:
     description: 'Builder node flags (deprecated, use nodes output instead)'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
   post: 'dist/index.js'


### PR DESCRIPTION
**Description:**

Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to `node20` (Node 20).

-----------------
A major version bump might be needed after the PRs merge.