### PR TITLE
`moby` image: add docker.io container registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,9 @@ jobs:
       fail-fast: false
       matrix:
         driver-opts:
-          - image=moby/buildkit:latest
+          - image=docker.io/moby/buildkit:latest
           - |
-            image=moby/buildkit:master
+            image=docker.io/moby/buildkit:master
             network=host
     steps:
       -
@@ -456,7 +456,7 @@ jobs:
               endpoint: ctxbuilder2
               platforms: linux/amd64
               driver-opts:
-                - image=moby/buildkit:master
+                - image=docker.io/moby/buildkit:master
                 - network=host
             - endpoint: ctxbuilder3
               platforms: linux/arm64
@@ -540,16 +540,16 @@ jobs:
           driver: kubernetes
           platforms: linux/amd64
           driver-opts: |
-            image=moby/buildkit:buildx-stable-1
+            image=docker.io/moby/buildkit:buildx-stable-1
             qemu.install=true
           append: |
             - platforms: linux/arm64
               driver-opts:
-                - image=moby/buildkit:buildx-stable-1
+                - image=docker.io/moby/buildkit:buildx-stable-1
                 - qemu.install=true
             - platforms: linux/s390x
               driver-opts:
-                - image=moby/buildkit:buildx-stable-1
+                - image=docker.io/moby/buildkit:buildx-stable-1
                 - qemu.install=true
       -
         name: Create Dockerfile

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following inputs can be used as `step.with` keys:
 > `List` type is a newline-delimited string
 > ```yaml
 > driver-opts: |
->   image=moby/buildkit:master
+>   image=docker.io/moby/buildkit:master
 >   network=host
 > ```
 
@@ -133,7 +133,7 @@ The following [official docker environment variables](https://docs.docker.com/en
      "endpoint": "unix:///var/run/docker.sock",
      "driver-opts": [
        "network=host",
-       "image=moby/buildkit:master"
+       "image=docker.io/moby/buildkit:master"
      ],
     "status": "running",
     "buildkitd-flags": "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host",

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -86,7 +86,7 @@ describe('getCreateArgs', () => {
       new Map<string, string>([
         ['install', 'false'],
         ['use', 'false'],
-        ['driver-opts', 'image=moby/buildkit:master\nnetwork=host'],
+        ['driver-opts', 'image=docker.io/moby/buildkit:master\nnetwork=host'],
         ['cache-binary', 'true'],
         ['cleanup', 'true'],
       ]),
@@ -94,7 +94,7 @@ describe('getCreateArgs', () => {
         'create',
         '--name', 'builder-9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d',
         '--driver', 'docker-container',
-        '--driver-opt', 'image=moby/buildkit:master',
+        '--driver-opt', 'image=docker.io/moby/buildkit:master',
         '--driver-opt', 'network=host',
         '--buildkitd-flags', '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host'
       ]
@@ -269,7 +269,7 @@ describe('getAppendArgs', () => {
         "name": "aws_graviton2",
         "endpoint": "ssh://me@graviton2",
         "driver-opts": [
-          "image=moby/buildkit:latest"
+          "image=docker.io/moby/buildkit:latest"
         ],
         "buildkitd-flags": "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host",
         "platforms": "linux/arm64"
@@ -279,7 +279,7 @@ describe('getAppendArgs', () => {
         '--name', 'builder-9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d',
         '--append',
         '--node', 'aws_graviton2',
-        '--driver-opt', 'image=moby/buildkit:latest',
+        '--driver-opt', 'image=docker.io/moby/buildkit:latest',
         '--buildkitd-flags', '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host',
         '--platform', 'linux/arm64',
         'ssh://me@graviton2'


### PR DESCRIPTION
Hi,
In docker, the container registry is supposed to be `docker.io`, but it can be others or even be undefined in other container runtimes (e.g. podman).
Thanks!