### PR TITLE
deprecate install input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,22 +115,6 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64,linux/ppc64le
 
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v6
-      -
-        name: Set up Docker Buildx
-        uses: ./
-        with:
-          install: true
-      -
-        name: Check cmd
-        run: |
-          docker build --help
-
   use:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The following inputs can be used as `step.with` keys:
 | `buildkitd-flags`            | String   |                    | [BuildKit daemon flags](https://docs.docker.com/engine/reference/commandline/buildx_create/#buildkitd-flags)                                                                |
 | `buildkitd-config` \*        | String   |                    | [BuildKit daemon config file](https://docs.docker.com/engine/reference/commandline/buildx_create/#config)                                                                   |
 | `buildkitd-config-inline` \* | String   |                    | Same as `buildkitd-config` but inline                                                                                                                                       |
-| `install`                    | Bool     | `false`            | Sets up `docker build` command as an alias to `docker buildx`                                                                                                               |
+| `install` \*                 | Bool     | `false`            | Sets up `docker build` command as an alias to `docker buildx`                                                                                                               |
 | `use`                        | Bool     | `true`             | Switch to this builder instance                                                                                                                                             |
 | `endpoint`                   | String   |                    | [Optional address for docker socket](https://docs.docker.com/engine/reference/commandline/buildx_create/#description) or context from `docker context ls`                   |
 | `platforms`                  | List/CSV |                    | Fixed [platforms](https://docs.docker.com/engine/reference/commandline/buildx_create/#platform) for current node. If not empty, values take priority over the detected ones |
@@ -110,6 +110,14 @@ The following inputs can be used as `step.with` keys:
 
 > [!NOTE]
 > `buildkitd-config` and `buildkitd-config-inline` are mutually exclusive.
+
+> [!NOTE]
+> `install` input is deprecated and will be removed in a future release. This
+>  input is not necessary when building with our actions like
+> `docker/build-push-action` or `docker/bake-action`. If you are still building
+> with the `docker build` command then you can set the `BUILDX_BUILDER`
+> environment variable, or you can just directly invoke the
+> `docker buildx build` command: https://github.com/docker/setup-buildx-action/pull/455
 
 ### outputs
 

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,6 @@ inputs:
   buildkitd-config-inline:
     description: 'Inline BuildKit daemon config'
     required: false
-  install:
-    description: 'Sets up docker build command as an alias to docker buildx build'
-    default: 'false'
-    required: false
   use:
     description: 'Switch to this builder instance'
     default: 'true'
@@ -58,7 +54,7 @@ inputs:
     description: 'Cleanup temp files and remove builder at the end of a job'
     default: 'true'
     required: false
-  # TODO: remove deprecated config and config-inline inputs
+  # TODO: remove deprecated config, config-inline and install inputs
   config:
     description: 'BuildKit daemon config file'
     deprecationMessage: 'Use buildkitd-config instead'
@@ -66,6 +62,11 @@ inputs:
   config-inline:
     description: 'Inline BuildKit daemon config'
     deprecationMessage: 'Use buildkitd-config-inline instead'
+    required: false
+  install:
+    description: 'Sets up docker build command as an alias to docker buildx build'
+    deprecationMessage: '"docker buildx install" command is deprecated and will be removed in a future release, use BUILDX_BUILDER environment variable instead'
+    default: 'false'
     required: false
 
 outputs:


### PR DESCRIPTION
follow-up:
* https://github.com/docker/buildx/pull/3472
* https://github.com/docker/docs/pull/23572

Buildx `install` command is deprecated since v0.30.0: https://github.com/docker/buildx/releases/tag/v0.30.0

People don't need to use it if they are using our `build-push-action` or `bake-action`. If they are not using our action and use `docker build` command instead, then they need to specify the `BUILDX_BUILDER` env var: https://docs.docker.com/build/builders/#difference-between-docker-build-and-docker-buildx-build

```yaml
      -
        name: Set up Docker Buildx
        id: builder
        uses: docker/setup-buildx-action@v3
      -
        name: Build
        run: |
          docker build .
        env:
          BUILDX_BUILDER: ${{ steps.builder.outputs.name }}
```

Or they can directly invoke `docker buildx build` command so they don't need to specify this env var.
